### PR TITLE
fix(tests): default the test suite to SQLite, keep Postgres as an opt-in

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -159,6 +159,11 @@ tasks:
 
   py:coverage:
     desc: run tests with coverage and open the HTML report
+    env:
+      # Default to SQLite so the .env loaded above can't aim a schema-dropping test run at a real
+      # Postgres database. An explicit `DB_ENGINE=postgres task py:coverage` still wins — the OS
+      # environment takes precedence over a task's env.
+      DB_ENGINE: sqlite
     cmds:
       - uv run pytest
       - uv run coverage report -m
@@ -217,6 +222,11 @@ tasks:
 
   py:test:
     desc: run python tests (args after '--')
+    env:
+      # Default to SQLite so the .env loaded above can't aim a schema-dropping test run at a real
+      # Postgres database. An explicit `DB_ENGINE=postgres task py:test` still wins — the OS
+      # environment takes precedence over a task's env.
+      DB_ENGINE: sqlite
     cmds:
       - uv run pytest {{ .CLI_ARGS }}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import contextlib
+import os
 from collections.abc import Generator
 
 from pytest import MonkeyPatch, fixture
@@ -6,6 +7,16 @@ from pytest import MonkeyPatch, fixture
 mp = MonkeyPatch()
 mp.setenv("PRODUCTION", "False")  # Set to False for testing (enables debug handlers)
 mp.setenv("TESTING", "True")
+
+# The suite defaults to SQLite, matching the app's own default, so a checkout whose .env points at a
+# real Postgres dev database doesn't become the target of a schema-dropping test run. This must run
+# before marvin.core.config is imported, since that calls dotenv.load_dotenv() to fold .env into the
+# environment. Only an already-exported DB_ENGINE wins, keeping `DB_ENGINE=postgres` available as an
+# opt-in (CI uses it against POSTGRES_DB=marvin_test) — see the guard in _create_test_schema, which
+# requires the target to be a test database. This covers a direct `pytest`; the Taskfile applies the
+# same default to `task py:test`, which needs its own because its `dotenv:` exports .env for us.
+if "DB_ENGINE" not in os.environ:
+    mp.setenv("DB_ENGINE", "sqlite")
 from pathlib import Path
 
 from fastapi.testclient import TestClient


### PR DESCRIPTION
## Problem

`task py:test` failed with **355 errors** — every test erroring at setup with the same message:

> `RuntimeError: Refusing to run the test suite against Postgres database 'marvin': it does not look like a test database, and the suite drops the entire schema on setup.`

The session-scoped `_create_test_schema` fixture drops the entire schema before running migrations, and it reads `DB_ENGINE`/`POSTGRES_DB` from the environment. A developer `.env` with `DB_ENGINE=postgres` therefore aimed the suite at the real dev database. The safety guard in `tests/conftest.py` caught it — without that guard the run would have wiped the database.

There were no actual test failures hiding behind this: the suite is **355 passed, 5 skipped** once pointed at the right backend.

## Fix

Default the suite to SQLite, matching the app's own default (`AppSettings.DB_ENGINE = "sqlite"`), in the two places that need it:

- **`tests/conftest.py`** — set before `marvin.core.config` folds `.env` into the environment via `dotenv.load_dotenv()`. Covers a direct `pytest` invocation.
- **`py:test` / `py:coverage`** — these need their own default because the Taskfile's `dotenv:` block already exports `.env` into the process environment, so `conftest` can no longer tell an `.env` value from an explicit one.

`DB_ENGINE=postgres` remains available as an explicit opt-in in both paths. go-task precedence is OS env > task `env` > dotenv, so an exported value still wins over the task default (verified empirically against go-task 3.43.3).

## Verification

Run against a checkout whose `.env` sets `DB_ENGINE=postgres` / `POSTGRES_DB=marvin`:

| Scenario | Result |
| --- | --- |
| `task py:test` | 355 passed, 5 skipped (SQLite) |
| `uv run pytest` | 355 passed, 5 skipped (SQLite) |
| `DB_ENGINE=postgres task py:test` | opt-in honored — guard fires, as it should for a non-test DB |
| `DB_ENGINE=postgres POSTGRES_DB=marvin_test` | engine resolves to `postgresql` / `marvin_test` |

CI is unaffected — `.github/workflows/test.yml` exports `DB_ENGINE: postgres` against `POSTGRES_DB: marvin_test`, which takes precedence and still satisfies the existing test-database guard.

`ruff check` on `tests/conftest.py` reports the same 3 pre-existing findings before and after; `ruff format --check` status is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012N9gMY1B8SB9WAb3VmGSdr