### PR TITLE
fix(ci): add pytest-cov so the coverage run works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,8 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage.lcov
+junit.xml
 *.cover
 .hypothesis/
 .pytest_cache/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -165,7 +165,10 @@ tasks:
       # environment takes precedence over a task's env.
       DB_ENGINE: sqlite
     cmds:
-      - uv run pytest
+      # --cov is what records the data; a bare `pytest` leaves the reporters below with nothing to
+      # read. `--cov-report=` silences pytest-cov's own terminal report so the explicit reporters
+      # that follow are the only output.
+      - uv run pytest --cov=src/marvin --cov-report=
       - uv run coverage report -m
       - uv run coverage lcov
       - uv run coverage html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ dev = [
     "mypy>=1.15.0",
     "pylint>=3.3.7",
     "pytest>=8.3.5",
+    "pytest-cov>=6.0.0",
     "python-dateutil>=2.9.0.post0",
     "python-semantic-release>=9.17.0",
     "rich>=14.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1055,6 +1055,7 @@ dev = [
     { name = "mypy" },
     { name = "pylint" },
     { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "python-dateutil" },
     { name = "python-semantic-release" },
     { name = "rich" },
@@ -1129,6 +1130,7 @@ dev = [
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "pylint", specifier = ">=3.3.7" },
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "python-semantic-release", specifier = ">=9.17.0" },
     { name = "rich", specifier = ">=14.0.0" },
@@ -1642,6 +1644,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "6.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/4c/f883ab8f0daad69f47efdf95f55a66b51a8b939c430dadce0611508d9e99/pytest_cov-6.3.0.tar.gz", hash = "sha256:35c580e7800f87ce892e687461166e1ac2bcb8fb9e13aea79032518d6e503ff2", size = 70398 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/b4/bb7263e12aade3842b938bc5c6958cae79c5ee18992f9b9349019579da0f/pytest_cov-6.3.0-py3-none-any.whl", hash = "sha256:440db28156d2468cafc0415b4f8e50856a0d11faefa38f30906048fe490f1749", size = 25115 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`Backend Tests (SQLite)` — described in `test.yml` as "the primary gate" — has been failing on `develop` with:

```
pytest: error: unrecognized arguments: --cov=src/marvin --cov-report=xml --cov-report=term
```

The `dev` dependency group carries `coverage` (the standalone tool) but not **`pytest-cov`**, the plugin that registers the `--cov*` options. `.github/workflows/test.yml:47-52` passes those flags, so pytest exited during argument parsing.

The important part: **the job never ran a single test.** The SQLite gate has been reporting red without executing the suite, so it has not been gating anything.

## Fix

Add `pytest-cov>=6.0.0` to the `dev` group. CI picks it up through its existing plain `uv sync` — uv syncs the `dev` group by default, which is why `pytest` itself was already present.

### Same root cause, second symptom

`task py:coverage` was broken in the same way, just silently. It ran a bare `pytest`, which records no coverage data, so the `coverage report -m` that followed exited with `No data to report.` It now runs `pytest --cov=src/marvin --cov-report=`, with pytest-cov's own terminal report suppressed so the explicit `coverage report/lcov/html` steps remain the only output.

`coverage.lcov` and `junit.xml` are gitignored — both paths now actually produce them.

## Verification

Ran against a clean `uv sync`, exactly as CI does:

| Check | Result |
| --- | --- |
| `import pytest_cov` after plain `uv sync` | 6.3.0 present |
| The job's exact pytest command | 355 passed, 5 skipped, TOTAL 52% |
| Artifacts the job uploads | `coverage.xml` + `junit.xml` both written |
| `py:coverage` pipeline | `coverage report -m` now reports (was "No data to report."), `coverage.lcov` written |
| `task py:test` | 355 passed, 5 skipped — unaffected |

`uv.lock` grows by 16 lines: pytest-cov only, since `coverage` and `pluggy` were already resolved.

## Not addressed

- `py:coverage` ends with `open htmlcov/index.html`, which is macOS-only and will fail on Linux. Left alone — changing it to `xdg-open` would break it for macOS users, so it needs a decision rather than a patch.
- `Backend Tests (PostgreSQL)` remains red for an unrelated reason: migration reversibility fails with `column "webhook_type" cannot be cast automatically to type eventdocumenttype`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012N9gMY1B8SB9WAb3VmGSdr