### PR TITLE
fix(ci): repair the Release version parse and the CLI migration step

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -88,6 +88,14 @@ jobs:
         run: |
           pip install -e ".[dev]"
 
+      # The SQLite file lives in <BASE_DIR>/dev/data, and BASE_DIR resolves to the repo's src/
+      # directory. Nothing under src/dev/data is tracked, so a fresh checkout doesn't have it, and
+      # the code that creates it (AppDirectories) only runs when the app starts — one step below.
+      # Without this, alembic fails with "unable to open database file".
+      - name: Create SQLite data directory
+        working-directory: marvin
+        run: mkdir -p src/dev/data
+
       - name: Run Alembic migrations
         working-directory: marvin/src/marvin
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,14 @@ jobs:
           # Run semantic-release to determine next version
           semantic-release version --print > version_info.txt || true
 
-          # Check if a new version was created
-          if [ -f "version_info.txt" ] && [ -s "version_info.txt" ]; then
-            NEW_VERSION=$(cat version_info.txt | grep -oP 'v\K[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?')
+          # Check if a new version was created. `--print` emits a bare version (e.g. 1.0.0-next.1)
+          # and nothing at all when no release is due — the "v" in tag_format applies to the git
+          # tag, not to this output, so the pattern must not require it. The `|| true` matters
+          # independently: GitHub runs this under `bash -e`, where a non-matching grep inside a
+          # command substitution aborts the whole step before anything below it runs.
+          NEW_VERSION=$(grep -oP '[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?' version_info.txt || true)
+
+          if [ -n "$NEW_VERSION" ]; then
             echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
             echo "released=true" >> $GITHUB_OUTPUT
             echo "📦 New version: $NEW_VERSION"


### PR DESCRIPTION
Two unrelated workflow failures on `develop`, fixed together because both are one-step CI bugs.

## 1. Release — a `grep` that could never match

`release.yml:67` scraped the next version with:

```bash
NEW_VERSION=$(cat version_info.txt | grep -oP 'v\K[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?')
```

The pattern requires a literal `v`, but `semantic-release version --print` emits a **bare** version — the `v` in `tag_format = "v{version}"` applies to the git tag, not to this output. Run against this repo it prints `1.0.0-next.1`, so the grep matched nothing and exited 1. GitHub runs the step under `bash -e`, where a failing command substitution aborts everything — which is why the logs showed neither `📦 New version` nor `ℹ️ No release needed`, and why `semantic-release version` / `publish` on lines 77-78 were never reached.

**The failure was conditional in the worst possible way.** When no release is due, `--print` writes nothing, the `else` branch runs, and the step passes. It broke *only* when a release was actually due.

Fixed by dropping the `v` requirement, guarding the substitution with `|| true`, and branching on whether a version was actually extracted — so unparseable output degrades to "no release needed" rather than killing the step.

Old vs new, both run under `bash -e`:

| `version_info.txt` | old | new |
| --- | --- | --- |
| `1.0.0-next.1` (real PSR output) | **exit 1, died** | exit 0 → `1.0.0-next.1` |
| `1.2.3` | **exit 1, died** | exit 0 → `1.2.3` |
| `v1.2.3` | exit 0 | exit 0 → `1.2.3` |
| empty (no release due) | exit 0 | exit 0 → no release needed |
| unparseable text | **exit 1, died** | exit 0 → no release needed |
| file missing | exit 0 | exit 0 → no release needed |

## 2. CLI Integration Tests — migrations ran before the data dir existed

`alembic upgrade head` failed with `sqlite3.OperationalError: unable to open database file`.

The SQLite file resolves to `<BASE_DIR>/dev/data/marvin.db`, and `BASE_DIR` is the repo's `src/` directory — so the real path is `src/dev/data`, which is untracked. A fresh CI checkout doesn't have it, and the only code that creates it (`AppDirectories`, `directories.py:53`) runs at app startup — the *next* step in the job.

Reproduced with an isolated `BASE_DIR`: alembic fails with the identical error, and creating the directory alone lets it run clean and produce a fully migrated DB.

Added a `Create SQLite data directory` step before the migration.

## Not addressed

`cli.yml:89` runs `pip install -e ".[dev]"`, but there is no `dev` **extra** — `[project.optional-dependencies]` defines only `openai`, `anthropic`, `google`, `ollama`, `all-ai`; `dev` is a PEP 735 dependency-group. pip warns and installs none of the dev tooling. Left alone as a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012N9gMY1B8SB9WAb3VmGSdr