### PR TITLE
fix(release): use a PEP 440 prerelease token on develop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,7 +199,11 @@ prerelease = false
 [tool.semantic_release.branches.develop]
 match = "develop"
 prerelease = true
-prerelease_token = "next"
+# Must be a PEP 440 pre-release marker — only "a", "b" and "rc" are legal. This yields
+# 1.0.0-rc.1, which normalizes to 1.0.0rc1. A token like "next" produces 1.0.0-next.1, which
+# hatchling rejects when semantic-release runs its build_command (`pip install -e .`) — failing
+# the release after the new version has already been written to pyproject.toml.
+prerelease_token = "rc"
 
 [tool.semantic_release.changelog]
 template_dir = "templates"


### PR DESCRIPTION
## Problem

With the version-parse fix in #15, the Release workflow finally reached `semantic-release version` — and failed one step later:

```
ValueError: Invalid version `1.0.0-next.1` from field `project.version`, see https://peps.python.org/pep-0440/
```

`pyproject.toml` set `prerelease_token = "next"` for the develop branch group. PEP 440 recognises only **`a`**, **`b`** and **`rc`** as pre-release markers, so `1.0.0-next.1` is not a valid version.

The ordering makes it worse: semantic-release writes the new version into `pyproject.toml` *before* running its `build_command` (`pip install -e .`). So hatchling rejected a version the tool had already committed to the file, and the release aborted mid-flight.

## Fix

`prerelease_token = "rc"`. semantic-release emits `1.0.0-rc.1`, which is valid PEP 440 and normalises to `1.0.0rc1`.

## Verification

Ran the real `build_command` against both strings, in a throwaway venv:

| `project.version` | PEP 440 | `pip install -e .` |
| --- | --- | --- |
| `1.0.0-next.1` | invalid | **fails** — reproduces the CI error exactly |
| `1.0.0-rc.1` | valid → `1.0.0rc1` | **builds clean** |

Also confirmed end to end:
- `semantic-release version --print` on a develop-matching branch now yields `1.0.0-rc.1` (was `1.0.0-next.1`).
- The `release.yml` grep from #15 extracts `1.0.0-rc.1` correctly, so the two fixes compose.
- Only the token changes — `project.version` stays at `0.2.0` for semantic-release to bump at release time.

## Notes

- **This unblocks a real release.** Once merged, the push to develop should publish `v1.0.0-rc.1`: a git tag, a `chore(release)` commit, a GitHub Release, plus the gated GHCR image and Helm chart.
- The major bump is legitimate, not an accident — 9 commits in history carry `BREAKING CHANGE` footers (e.g. "Implement schema-driven entry type system"). Because the existing `v0.1.x-test` tags are themselves unparseable by PEP 440, semantic-release sees no prior release, so this first changelog will cover the entire history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012N9gMY1B8SB9WAb3VmGSdr