### PR TITLE
fix(release): drop the unsupported {changelog} commit message placeholder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,10 @@ version_toml = ["pyproject.toml:project.version"]
 version_variables = ["src/marvin/__init__.py:__version__"]
 branch = "main"
 build_command = "pip install -e ."
-commit_message = "chore(release): {version} [skip ci]\n\n{changelog}"
+# Only {version} is substituted here — semantic-release formats this with version= alone, so any
+# other placeholder (e.g. {changelog}) raises KeyError and fails the release at commit time, after
+# the version bump and build have already succeeded. The changelog lives in CHANGELOG.md.
+commit_message = "chore(release): {version} [skip ci]"
 tag_format = "v{version}"
 upload_to_pypi = false
 upload_to_vcs_release = true


### PR DESCRIPTION
## Problem

The Release run after #16 got as far as `Build completed successfully!` and then died with a bare:

```
##[error] 'changelog'
```

That quoted string is a `KeyError` key. semantic-release formats the release commit message with `version` alone:

```python
# semantic_release/cli/commands/version.py:713
message=commit_message.format(version=new_version),
```

`pyproject.toml` used `commit_message = "chore(release): {version} [skip ci]\n\n{changelog}"`, so `{changelog}` raised `KeyError: 'changelog'`. Same shape as the previous two failures: it hit *late*, after the version bump and build had already succeeded, aborting at commit time.

## Fix

Keep `{version}` only. The changelog belongs in `CHANGELOG.md`, not the commit body.

## Verification

Ran a **full local release** on a develop-matching branch with `--no-push --no-vcs-release --skip-build` — exercising exactly the changelog + commit + tag path that was failing:

- next version computed: `1.0.0-rc.1`
- written to `pyproject.toml` and `src/marvin/__init__.py`
- commit created: `chore(release): 1.0.0-rc.1 [skip ci]`, **empty body**
- tag created: `v1.0.0-rc.1`
- **no KeyError**

The local commit and tag were discarded afterwards; this PR contains only the config change, with `version` left at `0.2.0` for semantic-release to bump.

## templates/ directory — checked, no action needed

`template_dir = "templates"` points at a directory that doesn't exist, but this is **harmless**:

- `changelog_writer.py:186` guards on `if template_dir.is_dir()`; when absent, `user_templates` stays empty and it falls through to the default template. The local run logged exactly that: `No contents found in '.../templates', using default changelog template`.
- `"templates"` is also semantic-release's own default (`config.py:176`), so the line only restates it.

Left as is.

## Separate finding: the changelog is never actually updated

The local run revealed something the earlier crashes were hiding — **`CHANGELOG.md` was not modified at all**, and it isn't in the release commit (only `pyproject.toml` and `__init__.py` are).

Cause: `changelog.mode` defaults to `UPDATE` (`config.py:174`), which inserts new entries after an insertion flag — `<!-- version list -->` for Markdown (`config.py:237`). The current hand-written `CHANGELOG.md` contains no such marker, so semantic-release has no insertion point and silently leaves the file alone.

Not fixed here: it needs a decision about the changelog's format, since adding the flag hands the file's structure over to semantic-release's default template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012N9gMY1B8SB9WAb3VmGSdr