### PR TITLE
ci(release): allow the Release workflow to be triggered manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
       - develop
+  # Manual trigger. Without this the workflow can only be exercised by landing a commit on a
+  # release branch, so a change to it cannot be validated before merge — and a push whose commit
+  # message carries the CI-skip marker leaves no way to run it at all.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Why

`release.yml` only triggered on pushes to `main`/`develop`. That had two costs.

**A change to the workflow could not be validated before merge.** Each of the three release fixes that landed recently (#15, #16, #17) had to be verified by local simulation, then revealed the *next* failure only once merged.

**A commit carrying the CI-skip marker suppresses every workflow for that push, with no way to recover.** That is exactly what happened to the merge of #17: the squash commit body quoted the marker verbatim while describing a verification result, GitHub matched it, and **no workflow ran at all** for that commit — zero runs, not a failure.

To be clear about the state: the `commit_message` fix from #17 **is** on `develop` and is correct (`pyproject.toml:193`). It simply never got a chance to execute.

## Change

Adds `workflow_dispatch:` to `release.yml`. Validated that the file still parses and resolves to `{'push': {'branches': ['main', 'develop']}, 'workflow_dispatch': None}`.

## Effect of merging

Two things follow:

1. This push to `develop` triggers Release normally, which should now run the full path — the `{changelog}` KeyError is gone, so it is expected to publish `v1.0.0-rc.1`: a git tag, a `chore(release)` commit, a GitHub Release, and the gated GHCR image and Helm chart.
2. Release becomes manually runnable from the Actions tab. Worth noting that is a real capability change — anyone able to dispatch workflows can start a release.

Reminder from #17, still true: `CHANGELOG.md` will not be updated by that release, because it lacks the `<!-- version list -->` insertion flag that `UPDATE` mode needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012N9gMY1B8SB9WAb3VmGSdr