### PR TITLE
fix(changelog): add the insertion flag so releases update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to the Marvin CMS server will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+<!-- version list -->
+
+## v1.0.0-rc.1 (2026-07-24)
+
+- Initial Release
 
 ## [0.2.0] - 2026-07-10
 
@@ -15,5 +19,4 @@ Initial version tracking setup with Python Semantic Release.
 - Automated changelog generation
 - GitHub Actions release workflow
 
-[Unreleased]: https://github.com/InnerOpen/marvin/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/InnerOpen/marvin/releases/tag/v0.2.0


### PR DESCRIPTION
## Problem

`v1.0.0-rc.1` shipped a tag, a GitHub Release, a GHCR image and a Helm chart — but no changelog entry. `CHANGELOG.md` still read `## [0.2.0]`.

semantic-release runs its changelog in `UPDATE` mode by default (`config.py:174`), inserting each new version *after* an insertion flag — `<!-- version list -->` for markdown (`config.py:237`). `CHANGELOG.md` contained no such marker, so there was no insertion point and the file was left untouched. Silently: no warning, no error, exit 0.

## Change

- Add `<!-- version list -->` in place of the empty `## [Unreleased]` heading. That heading had to go: new versions insert directly below the flag, so leaving it would have parked a permanently-empty "Unreleased" section *underneath* newer releases.
- Drop the now-dangling `[Unreleased]:` link reference it left behind.
- Backfill the `v1.0.0-rc.1` entry, generated by semantic-release itself. `UPDATE` mode only ever writes the release currently in flight, so rc.1 would otherwise have stayed missing permanently.

All hand-written content below the flag is preserved.

## Verification

Exercised with the real tool rather than reasoned about:

| Check | Result |
| --- | --- |
| `semantic-release changelog` **before** the flag | file byte-identical — reproduces the bug |
| `semantic-release changelog` **after** the flag | writes the `v1.0.0-rc.1` section under the flag |
| Simulated follow-up release (`--no-push --no-vcs-release --skip-build`) | renders `v1.0.0-rc.2` with full `### Bug Fixes` / `### Chores` sections and commit links, inserted **above** rc.1 |
| Release commit contents | `CHANGELOG.md` now included alongside `pyproject.toml` and `__init__.py` — it never was before |

All simulation commits and the scratch `v1.0.0-rc.2` tag were discarded; this PR is a 5-line changelog edit and nothing else.

## Note on the rc.1 entry body

It reads `- Initial Release` rather than listing changes. That is deliberate on semantic-release's part: `mask_initial_release` defaults to `true` (`config.py:145`), which summarises the first release instead of dumping the entire repository history into it. Every subsequent release gets full categorised entries, as the rc.2 simulation above shows. Set `mask_initial_release = false` if you would rather rc.1 list everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012N9gMY1B8SB9WAb3VmGSdr