### PR TITLE
fix(migrations): make the webhook_type enum change reversible on Postgres

### DIFF
--- a/src/marvin/alembic/versions/2026-07-16-00.00.02_f6a7b8c9d0eb_webhook_type_and_custom_payload.py
+++ b/src/marvin/alembic/versions/2026-07-16-00.00.02_f6a7b8c9d0eb_webhook_type_and_custom_payload.py
@@ -52,16 +52,39 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    with op.batch_alter_table("webhook_urls") as batch_op:
-        batch_op.drop_column("custom_payload")
-        batch_op.alter_column(
+    bind = op.get_bind()
+    old_enum = sa.Enum("generic", "user", name="eventdocumenttype")
+    new_enum = sa.Enum("generic", "user", "entries", "event_driven", name="webhookmode")
+    if bind.dialect.name == "postgresql":
+        # Mirror of upgrade(): Postgres won't cast between two enum types on its own, so the
+        # reverse direction needs its own USING clause. Rows holding a value the old enum never
+        # had are folded back to 'generic' first — the cast would otherwise reject them.
+        op.drop_column("webhook_urls", "custom_payload")
+        op.execute("UPDATE webhook_urls SET webhook_type = 'generic' WHERE webhook_type IN ('entries', 'event_driven')")
+        old_enum.create(bind, checkfirst=True)
+        op.alter_column(
+            "webhook_urls",
             "webhook_type",
-            existing_type=sa.Enum("generic", "user", "entries", "event_driven", name="webhookmode"),
-            type_=sa.Enum("generic", "user", name="eventdocumenttype"),
+            existing_type=new_enum,
+            type_=old_enum,
             existing_nullable=True,
+            postgresql_using="webhook_type::text::eventdocumenttype",
         )
-        batch_op.alter_column(
-            "scheduled_time",
-            existing_type=sa.DateTime(timezone=True),
-            nullable=False,
-        )
+        op.alter_column("webhook_urls", "scheduled_time", existing_type=sa.DateTime(timezone=True), nullable=False)
+        # Nothing references the expanded type once the column is back on the old one; leaving it
+        # behind would strand a type the upgrade created.
+        new_enum.drop(bind, checkfirst=True)
+    else:
+        with op.batch_alter_table("webhook_urls") as batch_op:
+            batch_op.drop_column("custom_payload")
+            batch_op.alter_column(
+                "webhook_type",
+                existing_type=new_enum,
+                type_=old_enum,
+                existing_nullable=True,
+            )
+            batch_op.alter_column(
+                "scheduled_time",
+                existing_type=sa.DateTime(timezone=True),
+                nullable=False,
+            )


### PR DESCRIPTION
## Problem

`Backend Tests (PostgreSQL)` failed its `up -> down -> up` reversibility check with:

```
psycopg2.errors.DatatypeMismatch: column "webhook_type" cannot be cast automatically to type eventdocumenttype
```

`upgrade()` already handled Postgres correctly — it branches on the dialect and casts through text with `postgresql_using`. `downgrade()` did neither: it called `batch_alter_table` unconditionally, which on Postgres emits a plain `ALTER COLUMN`, and Postgres will not cast between two enum types without an explicit `USING` clause.

## Fix

Give `downgrade()` the same shape as `upgrade()`:

- branch on the dialect, keeping batch mode for SQLite only
- cast with `postgresql_using` on the way back down
- fold `entries` and `event_driven` to `generic` **before** casting — the old enum has no such values, so the cast would reject those rows
- drop the `webhookmode` type once the column no longer uses it, rather than stranding a type the upgrade created

## Verification

Run against a real **Postgres 16** in a throwaway container (your dev database on 5434 was not touched):

| Check | Result |
| --- | --- |
| Original code, `downgrade base` | reproduces `DatatypeMismatch` |
| After fix, `upgrade head` | column is `webhookmode` |
| After fix, downgrade across the revision | column is `eventdocumenttype`, `custom_payload` dropped, `webhookmode` type gone |
| After fix, re-`upgrade head` | column back to `webhookmode` |
| Downgrade **with rows present** | `entries` → `generic`, `event_driven` → `generic`, `user` preserved |
| SQLite up → down → up | clean; `webhook_type` and `custom_payload` restored |
| Test suite | 355 passed, 5 skipped |
| ruff check / format | clean |

## Two things this does not fix

**1. The reversibility job will still fail, further down the chain.** With the enum cast fixed, `alembic downgrade base` now gets much deeper and hits a separate, unrelated bug:

```
psycopg2.errors.DependentObjectsStillExist: cannot drop table users because other objects depend on it
```

That is a different migration's `downgrade()` dropping `users` while dependent objects remain. Out of scope here, but it is the next thing standing between this job and green.

**2. Downgrading with data still fails on `scheduled_time`.** The upgrade makes the column nullable; the downgrade restores `NOT NULL`, which fails if any row has a NULL:

```
psycopg2.errors.NotNullViolation: column "scheduled_time" of relation "webhook_urls" contains null values
```

This behaviour is unchanged from before this PR, and CI does not hit it because the reversibility check runs against an empty database. I left it alone deliberately: fixing it means choosing a backfill value for existing NULLs, which is a data-semantics decision rather than a mechanical one. (By contrast the `entries`/`event_driven` fold above is forced — those values simply cannot exist in the old enum.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012N9gMY1B8SB9WAb3VmGSdr